### PR TITLE
feat: add inactive user detection with 90-day activity threshold

### DIFF
--- a/iam_audit.py
+++ b/iam_audit.py
@@ -5,6 +5,7 @@ Checks performed:
     1. Console Access - Does the user have a password to log into AWS Console?
     2. MFA Status - If they have console access, is MFA enabled?
     3. Access Key Age - Are any active access keys older than 90 days?
+    4. User Activity - Has the user been inactive for 90+ days?
 Output:
     [PASS] - Console user with MFA enabled / Access key within rotation period
     [FAIL] - Console user WITHOUT MFA / Active access key over 90 days old
@@ -39,7 +40,8 @@ def export_to_csv(audit_results, timestamp):
 
     fieldnames = [
         'username', 'has_console_access', 'mfa_enabled', 'compliance_status',
-        'access_key_count', 'oldest_key_age_days', 'key_compliance_status'
+        'access_key_count', 'oldest_key_age_days', 'key_compliance_status',
+        'last_activity_date', 'days_inactive', 'activity_status'
     ]
 
     with open(filename, 'w', newline='') as csvfile:
@@ -71,7 +73,9 @@ def export_to_json(audit_results, metadata, timestamp):
             'elapsed_seconds': metadata['elapsed_seconds'],
             'total_users': metadata['total_users'],
             'compliance_rate': metadata['compliance_rate'],
-            'key_compliance_rate': metadata['key_compliance_rate']
+            'key_compliance_rate': metadata['key_compliance_rate'],
+            'activity_compliance_rate': metadata['activity_compliance_rate'],
+            'inactive_users': metadata['inactive_users']
         },
         'findings': audit_results
     }
@@ -82,22 +86,27 @@ def export_to_json(audit_results, metadata, timestamp):
     return filename
 
 
-def audit_user(iam, username):
+def audit_user(iam, user):
     """
-    Audit a single IAM user for MFA and access key compliance.
+    Audit a single IAM user for MFA, access key, and activity compliance.
 
     Checks whether the user has console access, whether MFA is enabled,
-    and whether any active access keys exceed the 90-day rotation threshold.
+    whether any active access keys exceed the 90-day rotation threshold,
+    and whether the user has been inactive for 90+ days.
 
     Args:
         iam: boto3 IAM client
-        username: IAM username to audit
+        user: User dictionary from list_users() containing UserName,
+              CreateDate, and optionally PasswordLastUsed
 
     Returns:
         dict containing user audit results with keys: username,
         has_console_access, mfa_enabled, compliance_status,
-        access_key_count, oldest_key_age_days, key_compliance_status
+        access_key_count, oldest_key_age_days, key_compliance_status,
+        last_activity_date, days_inactive, activity_status
     """
+    username = user['UserName']
+    now_utc = datetime.now(timezone.utc)
     print(f"Checking: {username}")
 
     # Paginate list_mfa_devices() for completeness. Empty list means no MFA.
@@ -137,7 +146,6 @@ def audit_user(iam, username):
     key_compliance = 'N/A'
 
     if access_keys:
-        now_utc = datetime.now(timezone.utc)
         user_keys_compliant = True
 
         for key in access_keys:
@@ -164,6 +172,38 @@ def audit_user(iam, username):
     else:
         print("    [N/A] No access keys.")
 
+    # Determine last activity date for inactivity detection.
+    # AC-2(3) requires disabling accounts inactive beyond a defined threshold.
+    # Start with CreateDate as baseline (timezone-aware UTC from boto3).
+    last_activity = user['CreateDate']
+
+    # PasswordLastUsed is only present if the user has signed in via console
+    # at least once. dict.get() returns None when the key is missing (PCC3e
+    # Ch. 6), avoiding a KeyError for programmatic-only users.
+    password_last_used = user.get('PasswordLastUsed')
+    if password_last_used and password_last_used > last_activity:
+        last_activity = password_last_used
+
+    # Check each access key's last used date for programmatic activity.
+    # get_access_key_last_used() is a direct call (not paginated) since
+    # it returns a single result per key.
+    for key in access_keys:
+        key_last_used_info = iam.get_access_key_last_used(
+            AccessKeyId=key['AccessKeyId']
+        )
+        key_last_used = key_last_used_info['AccessKeyLastUsed'].get('LastUsedDate')
+        if key_last_used and key_last_used > last_activity:
+            last_activity = key_last_used
+
+    days_inactive = (now_utc - last_activity).days
+
+    if days_inactive > 90:
+        print(f"    [FAIL] Inactive for {days_inactive} days (last activity: {last_activity.strftime('%Y-%m-%d')})")
+        activity_status = 'FAIL'
+    else:
+        print(f"    [PASS] Active within 90 days (last activity: {last_activity.strftime('%Y-%m-%d')})")
+        activity_status = 'PASS'
+
     return {
         'username': username,
         'has_console_access': has_console,
@@ -171,7 +211,10 @@ def audit_user(iam, username):
         'compliance_status': compliance_status,
         'access_key_count': len(access_keys),
         'oldest_key_age_days': oldest_key_age,
-        'key_compliance_status': key_compliance
+        'key_compliance_status': key_compliance,
+        'last_activity_date': last_activity.strftime('%Y-%m-%d'),
+        'days_inactive': days_inactive,
+        'activity_status': activity_status
     }
 
 
@@ -196,9 +239,9 @@ def run_audit():
     audit_results = []
     audit_start = datetime.now()
 
-    # Check each user for MFA and access key compliance.
+    # Check each user for MFA, access key, and activity compliance.
     for user in users:
-        result = audit_user(iam, user['UserName'])
+        result = audit_user(iam, user)
         audit_results.append(result)
 
     # Capture audit completion time and calculate elapsed time.
@@ -210,6 +253,7 @@ def run_audit():
     no_console_count = sum(1 for r in audit_results if r['compliance_status'] == 'INFO')
     keys_compliant_count = sum(1 for r in audit_results if r['key_compliance_status'] == 'PASS')
     keys_noncompliant_count = sum(1 for r in audit_results if r['key_compliance_status'] == 'FAIL')
+    inactive_count = sum(1 for r in audit_results if r['activity_status'] == 'FAIL')
 
     # Compliance summary of results.
     print("\n" + "=" * 40)
@@ -227,9 +271,14 @@ def run_audit():
     print(f"  Compliant: {keys_compliant_count}")
     print(f"  Non-compliant: {keys_noncompliant_count}")
 
+    print(f"\nUser Activity (90-day inactivity threshold):")
+    print(f"  Active: {total_users - inactive_count}")
+    print(f"  Inactive (90+ days): {inactive_count}")
+
     # Calculate compliance rates for GRC reporting.
     compliance_rate = (compliant_count / total_users * 100) if total_users > 0 else 0
     key_compliance_rate = (keys_compliant_count / users_with_keys * 100) if users_with_keys > 0 else 0
+    activity_compliance_rate = ((total_users - inactive_count) / total_users * 100) if total_users > 0 else 0
 
     # Display audit trail timestamps.
     print(f"\nAudit started: {audit_start.isoformat()}")
@@ -237,6 +286,7 @@ def run_audit():
     print(f"Elapsed time: {elapsed:.2f} seconds")
     print(f"MFA compliance rate: {compliance_rate:.1f}%")
     print(f"Key compliance rate: {key_compliance_rate:.1f}%")
+    print(f"Activity compliance rate: {activity_compliance_rate:.1f}%")
 
     # Export results to CSV and JSON for compliance reporting.
     timestamp_str = audit_start.isoformat().replace(':', '-').split('.')[0]
@@ -247,7 +297,9 @@ def run_audit():
         'elapsed_seconds': elapsed,
         'total_users': total_users,
         'compliance_rate': f"{compliance_rate:.1f}%",
-        'key_compliance_rate': f"{key_compliance_rate:.1f}%"
+        'key_compliance_rate': f"{key_compliance_rate:.1f}%",
+        'activity_compliance_rate': f"{activity_compliance_rate:.1f}%",
+        'inactive_users': inactive_count
     }
 
     csv_file = export_to_csv(audit_results, timestamp_str)


### PR DESCRIPTION
## Summary

* Add inactivity detection to `audit_user()` by checking `PasswordLastUsed`, `get_access_key_last_used()`, and `CreateDate` to determine each user's most recent activity
* Flag users inactive for 90+ days as `[FAIL]` per AC-2(3) requirements
* Add `last_activity_date`, `days_inactive`, and `activity_status` fields to CSV and JSON exports
* Add activity compliance rate and inactive user count to audit summary and JSON metadata

## Controls Addressed

* AC-2(3): Disable inactive accounts after a defined period of inactivity

## Test Plan

- [X] Run `python iam_audit.py` against AWS account
- [X] Verify `[PASS]`/`[FAIL]` activity status prints correctly per user
- [X] Verify CSV export includes `last_activity_date`, `days_inactive`, `activity_status` columns
- [X] Verify JSON export includes `activity_compliance_rate` and `inactive_users` in metadata
- [X] Verify JSON findings include the three new fields per user

Closes 0xBahalaNa/iam-audit#4<br>Closes 0xBahalaNa/iam-audit#4