### PR TITLE
feat: add .gitignore for audit outputs and Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Audit output files — contain AWS account IDs, IAM usernames, and
+# compliance findings. Never commit these to a public portfolio repo.
+iam_audit_*.csv
+iam_audit_*.json
+
+# Python bytecode and caches
+__pycache__/
+*.pyc
+
+# Environment files (may contain AWS credentials or SNS ARNs)
+.env


### PR DESCRIPTION
## Summary
- Added `.gitignore` blocking `iam_audit_*.csv` and `iam_audit_*.json` so audit output (AWS account IDs, IAM usernames, compliance findings) cannot be committed to the public portfolio repo
- Ignores `__pycache__/` and `*.pyc` (Python bytecode)
- Ignores `.env` to keep AWS credentials and SNS ARNs out of git history

## Test Plan
- [x] `git check-ignore -v` confirms all patterns match (`iam_audit_*.csv`, `iam_audit_*.json`, `__pycache__/foo.pyc`, `test.pyc`, `.env`)
- [x] `git status` on main branch no longer lists the previously-untracked `__pycache__/` directory
- [x] No existing tracked files affected (new file only)

Closes #14
Closes 0XBN-68