### PR TITLE
docs: surface v2.0/pause decision, redirect access-review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,16 @@ FedRAMP 20x shifts evidence collection from point-in-time documents to continuou
 
 The JSON output is the stable machine interface; downstream consumers (`evidence-logger`, OSCAL assemblers) can ingest findings without parsing console text. The `metadata` block (audit timestamps, `total_users`, `compliance_rate`) maps directly to OSCAL Assessment Results observation records.
 
-## Future Enhancements
+## Roadmap
 
-- Access review workflow module — certification and approval workflows for quarterly user access reviews (AC-2(1), AC-2(3))
+The access-review workflow originally floated as a Future Enhancement has been spun out as a standalone v1.0 milestone in [`iam-access-review`](https://github.com/0xBahalaNa/iam-access-review) (Month 5, July 2026).
+
+v2.0 scope for **this** repo is **under review with a decision target of 2026-06-30**. Two paths:
+
+- **Active path:** lock a v2.0 scope (candidate enhancements: access-key rotation analytics, service-account audit, cross-account roll-up) and resume sprint cadence.
+- **Maintenance path:** formally mark v1.1 complete, community PRs reviewed on best-effort basis; IAM evidence work continues in [`iam-access-review`](https://github.com/0xBahalaNa/iam-access-review) and the broader IAM evidence layer of [`oscal-evidence-pipeline`](https://github.com/0xBahalaNa/oscal-evidence-pipeline) without expanding this tool.
+
+The JSON output already supports downstream consumption by `oscal-evidence-pipeline` as a Component Definition source — neither path changes that integration surface.
 
 ## Framework Reference
 


### PR DESCRIPTION
## Summary

- Add a **Roadmap** section to honestly surface the v2.0-vs-maintenance decision (target: 2026-06-30) — explicitly lists both paths with candidate v2.0 scope so a reader isn't left guessing whether the repo is silently abandoned
- Redirect the dangling **Future Enhancements** access-review workflow item: it has been spun out as standalone v1.0 milestone in \`iam-access-review\` (Month 5). The line was misleading after that decision; removed in favor of the new Roadmap framing.
- Clarify that JSON output stays as the stable contract feeding \`oscal-evidence-pipeline\` regardless of which path v2.0 takes

## Test Plan

- [x] Roadmap renders between *FedRAMP 20x Alignment* and *Framework Reference*
- [ ] \`iam-access-review\` cross-link (placeholder until repo lands Month 5)
- [ ] Stale \`sprint-month-4\` label removed from the repo's label inventory (handled outside this PR)