### PR TITLE
docs: add README badges for portfolio visual coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+![License](https://img.shields.io/badge/License-MIT-green?style=flat)
+![Python](https://img.shields.io/badge/Python-3.11%2B-3776ab?style=flat)
+![AWS](https://img.shields.io/badge/AWS-IAM-FF9900?style=flat&logo=amazonwebservices)
+![NIST 800-53](https://img.shields.io/badge/NIST-800--53%20Rev%205-004990?style=flat)
+![FedRAMP](https://img.shields.io/badge/FedRAMP-High%20Baseline-0071bc?style=flat)
+![CJIS](https://img.shields.io/badge/CJIS-Security%20Policy%20v6.0-cc0000?style=flat)
+
 # IAM Audit
 
 A Python tool that audits all IAM users in your AWS account for MFA compliance.


### PR DESCRIPTION
## Summary
- Adds the standardized 6-badge block to the top of `README.md` (License, Python 3.11+, AWS IAM, NIST 800-53 Rev 5, FedRAMP High Baseline, CJIS Security Policy v6.0)
- Matches the portfolio house style used in `aws-compliance-as-code`, `aws-config-compliance-monitor`, and `aws-grc-terraform-modules`
- No body content changed below the badge block

## Test Plan
- [ ] Open the README on GitHub after merge and confirm all six badges render in order
- [ ] Confirm the H1 and Overview sections still appear unchanged below the badges
- [ ] Spot-check the badge order against `aws-grc-terraform-modules` README for portfolio consistency

Closes #30